### PR TITLE
Allows to modify file depth from an external caller

### DIFF
--- a/log4go.go
+++ b/log4go.go
@@ -49,7 +49,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-    "path/filepath"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -81,7 +81,7 @@ const (
 )
 
 // Default level passed to runtime.Caller
-const DefaultFileDepth int = 2
+var DefaultFileDepth int = 2
 
 // Logging level strings
 var (


### PR DESCRIPTION
We use Log4Go in our project with a centralized wrapper that, among other things executes `log4go`'s logging. If `DefaultFileDepth` is a constant, we will see the name of the package as the wrapper one, instead of the original caller, which is one level up. With this modification we can modify `DefaultFileDepth` outside, so it passes a `3`, that'll allows us to track an additional level up and not the wrapper package.
